### PR TITLE
updated length of rmarks in icops table.

### DIFF
--- a/src/main/resources/db/migration/main/V20240830134500__icops-tracker_ddl.sql
+++ b/src/main/resources/db/migration/main/V20240830134500__icops-tracker_ddl.sql
@@ -1,0 +1,3 @@
+ALTER TABLE dristi_kerala_icops
+ALTER COLUMN remarks TYPE VARCHAR(128);
+ 

--- a/src/main/resources/db/migration/main/V20240830134500__icops-tracker_ddl.sql
+++ b/src/main/resources/db/migration/main/V20240830134500__icops-tracker_ddl.sql
@@ -1,3 +1,3 @@
 ALTER TABLE dristi_kerala_icops
-ALTER COLUMN remarks TYPE VARCHAR(128);
+ALTER COLUMN remarks TYPE VARCHAR(1000);
  


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `remarks` field in the database to support longer text entries, accommodating up to 1000 characters for improved usability.

- **Bug Fixes**
	- Resolved issues related to data entry limitations in the `remarks` field, allowing for more detailed comments and descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->